### PR TITLE
Fixed tomorrow empty table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "kouran"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ homepage = "https://github.com/k3ii/kouran"
 readme = "README.md"
 keywords = ["cli"]
 categories = ["command-line-utilities"]
+rust-version = "1.74.1"
+
 
 [dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kouran"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Jain Ramchurn"]
 description = "View Power Outages in Mauritius"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use clap::Command;
 
 pub fn cli() -> Command {
     Command::new("courant")
-        .version("0.1.1")
+        .version("0.1.2")
         .author("Jain Ramchurn")
         .subcommand(
             Command::new("today")

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,11 @@ fn print_outage_events(events: &[OutageEvent], title: &str, is_today: bool) {
         return;
     }
 
+    if events.is_empty() && !is_today {
+        println!("There are no planned outages scheduled for tomorrow. 🎉");
+        return;
+    }
+
     let mut table = Table::new();
     let utc_plus_4 = FixedOffset::east_opt(4 * 3600).expect("Unable to create UTC+4 offset");
     let now = Utc::now().with_timezone(&utc_plus_4);


### PR DESCRIPTION
- **chore(cargo): Add rust-version metadata**
- **fix: output message when event for tomorrow is empty**
- **chore: bump version to 0.1.2**
